### PR TITLE
test: update tests to support latest google-cloud-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.32.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
-dependencies = ["google-cloud-core == 1.4.2rc2"]
+dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.32.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
-dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
+dependencies = ["google-cloud-core == 1.4.2rc1"]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.32.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
-dependencies = ["google-cloud-core == 1.4.2rc1"]
+dependencies = ["google-cloud-core == 1.4.2rc2"]
 extras = {}
 
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -32,11 +32,46 @@ class TestConnection(unittest.TestCase):
         conn = self._make_one(client)
         self.assertIs(conn._client, client)
 
+    def test_build_api_url_no_extra_query_params(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
+        conn = self._make_one(object())
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
+
     def test_build_api_url_w_custom_endpoint(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         custom_endpoint = "https://foo-runtimeconfig.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
-        URI = "/".join([custom_endpoint, conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
+
+    def test_build_api_url_w_extra_query_params(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
+        conn = self._make_one(object())
+        uri = conn.build_api_url("/foo", {"bar": "baz"})
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        self.assertEqual(parms["bar"], "baz")
 
     def test_extra_headers(self):
         import requests


### PR DESCRIPTION
`google-cloud-core` version 1.4.2 populates `prettyPrint=false` by
default. Update the connection tests to expect a value for
`prettyPrint`.

This PR also serves to test that the changes in googleapis/python-cloud-core#28 do not break this library.