### PR TITLE
fix: remove six

### DIFF
--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -33,8 +33,8 @@ class TestConnection(unittest.TestCase):
         self.assertIs(conn._client, client)
 
     def test_build_api_url_no_extra_query_params(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         conn = self._make_one(object())
         uri = conn.build_api_url("/foo")
@@ -47,8 +47,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(parms, {})
 
     def test_build_api_url_w_custom_endpoint(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         custom_endpoint = "https://foo-runtimeconfig.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
@@ -62,8 +62,8 @@ class TestConnection(unittest.TestCase):
         self.assertEqual(parms, {})
 
     def test_build_api_url_w_extra_query_params(self):
-        from six.moves.urllib.parse import parse_qsl
-        from six.moves.urllib.parse import urlsplit
+        from urllib.parse import parse_qsl
+        from urllib.parse import urlsplit
 
         conn = self._make_one(object())
         uri = conn.build_api_url("/foo", {"bar": "baz"})

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -212,14 +212,12 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % (VARIABLE_PATH,))
 
     def test_list_variables_empty(self):
-        import six
-
         conn = _Connection({})
         client = _Client(project=self.PROJECT, connection=conn)
         config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         iterator = config.list_variables()
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         variables = list(page)
         token = iterator.next_page_token
 
@@ -232,7 +230,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(req["path"], "/%s" % (PATH,))
 
     def test_list_variables_defaults(self):
-        import six
         from google.cloud._helpers import _rfc3339_to_datetime
         from google.cloud.runtimeconfig.variable import Variable
 
@@ -259,7 +256,7 @@ class TestConfig(unittest.TestCase):
         config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         iterator = config.list_variables()
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         variables = list(page)
         token = iterator.next_page_token
 
@@ -279,7 +276,6 @@ class TestConfig(unittest.TestCase):
         self.assertNotIn("filter", req["query_params"])
 
     def test_list_variables_explicit(self):
-        import six
         from google.cloud._helpers import _rfc3339_to_datetime
         from google.cloud.runtimeconfig.variable import Variable
 
@@ -305,7 +301,7 @@ class TestConfig(unittest.TestCase):
         config = self._make_one(name=self.CONFIG_NAME, client=client)
 
         iterator = config.list_variables(page_size=3, page_token=TOKEN, client=client)
-        page = six.next(iterator.pages)
+        page = next(iterator.pages)
         variables = list(page)
         token = iterator.next_page_token
 


### PR DESCRIPTION
Six was used in the tests for Python 2 compatibility and is no longer needed.


Fixes #90, #91, #92, #93, #94, #95, #96, #97, #98 🦕