### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "runtimeconfig",
-  "name_pretty": "Google Cloud Runtime Configurator",
-  "product_documentation": "https://cloud.google.com/deployment-manager/runtime-configurator/",
-  "client_documentation": "https://googleapis.dev/python/runtimeconfig/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559663",
-  "release_level": "beta",
-  "language": "python",
-  "library_type": "GAPIC_MANUAL",
-  "repo": "googleapis/python-runtimeconfig",
-  "distribution_name": "google-cloud-runtimeconfig",
-  "api_id": "runtimeconfig.googleapis.com",
-  "requires_billing": true
+    "name": "runtimeconfig",
+    "name_pretty": "Google Cloud Runtime Configurator",
+    "product_documentation": "https://cloud.google.com/deployment-manager/runtime-configurator/",
+    "client_documentation": "https://googleapis.dev/python/runtimeconfig/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559663",
+    "release_level": "beta",
+    "language": "python",
+    "library_type": "GAPIC_MANUAL",
+    "repo": "googleapis/python-runtimeconfig",
+    "distribution_name": "google-cloud-runtimeconfig",
+    "api_id": "runtimeconfig.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114