### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "runtimeconfig",
     "name_pretty": "Google Cloud Runtime Configurator",
     "product_documentation": "https://cloud.google.com/deployment-manager/runtime-configurator/",
-    "client_documentation": "https://googleapis.dev/python/runtimeconfig/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/runtimeconfig/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559663",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ return based on certain conditions.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-runtimeconfig.svg
    :target: https://pypi.org/project/google-cloud-runtimeconfig/
 .. _Google Cloud RuntimeConfig: https://cloud.google.com/deployment-manager/runtime-configurator/
-.. _Client Library Documentation: https://googleapis.dev/python/runtimeconfig/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/runtimeconfig/latest
 .. _Product Documentation: https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.