### PR TITLE
chore: Update version of python-runtimeconfig to v0.35.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-cloud-runtimeconfig
-    version: 0.35.1
+    version: 0.35.0
     apis: []
     source_roots:
       - .


### PR DESCRIPTION
There is no v0.35.1 tag, so we must update the version in state.yaml to v0.35.0.
