### PR TITLE
chore: librarian release pull request: 20251113T194817Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-cloud-runtimeconfig
-    version: 0.35.0
+    version: 0.35.1
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-cloud-runtimeconfig/#history
 
+## [0.35.1](https://github.com/googleapis/google-cloud-python/compare/google-cloud-runtimeconfig-v0.35.0...google-cloud-runtimeconfig-v0.35.1) (2025-11-13)
+
+
+### Bug Fixes
+
+* remove setup.cfg configuration for creating universal wheels (#321) ([922db8cec6b2896087d95dc7f360a4b2edeaaea0](https://github.com/googleapis/google-cloud-python/commit/922db8cec6b2896087d95dc7f360a4b2edeaaea0))
+* resolve issues where pre-release versions of dependencies are installed (#318) ([14337044ae5d5c33a10f4a9dbb322db3352963e2](https://github.com/googleapis/google-cloud-python/commit/14337044ae5d5c33a10f4a9dbb322db3352963e2))
+
 ## [0.35.0](https://github.com/googleapis/python-runtimeconfig/compare/v0.34.0...v0.35.0) (2025-01-30)
 
 

--- a/google/cloud/runtimeconfig/version.py
+++ b/google/cloud/runtimeconfig/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.35.0"
+__version__ = "0.35.1"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-cloud-runtimeconfig: 0.35.1</summary>

## [0.35.1](https://github.com/googleapis/python-runtimeconfig/compare/v0.35.0...v0.35.1) (2025-11-13)

### Bug Fixes

* resolve issues where pre-release versions of dependencies are installed (#318) ([14337044](https://github.com/googleapis/python-runtimeconfig/commit/14337044))

* remove setup.cfg configuration for creating universal wheels (#321) ([922db8ce](https://github.com/googleapis/python-runtimeconfig/commit/922db8ce))

</details>